### PR TITLE
correct logic for fb intraday

### DIFF
--- a/import_data/activity_parsers.py
+++ b/import_data/activity_parsers.py
@@ -124,15 +124,14 @@ def fitbit_intraday_parser(
                 "fitbit-intraday-(.*?)\.json", file_info["basename"]
             ).groups()[0]
             yearmonth = arrow.get(yearmonth)
+
+            if yearmonth.floor(
+                "month"
+            ) <= period_end and period_start <= yearmonth.ceil("month"):
+                data = json.loads(requests.get(file_info["download_url"]).content)
+                hr_data = hr_data + data["activities-heart-intraday"]
         except AttributeError:
             continue
-
-        if yearmonth.floor("month") <= period_end or period_start <= yearmonth.ceil(
-            "month"
-        ):
-            data = json.loads(requests.get(file_info["download_url"]).content)
-            hr_data = hr_data + data["activities-heart-intraday"]
-
     # load into dataframe
     rows = []
     for hr_point in hr_data:


### PR DESCRIPTION
Currently the Fitbit intraday logic is broken because does an `or` for identifying the correct files. This leads to it trying to read in _all_ data prior to a given date which even crashes my local development machine with 16 GB ram. 

Poor heroku workers 😂 

This fixes it. @madprime I'll merge right away and deploy!