### PR TITLE
add google fit texts to frontend & fix transparent navbar for mobile

### DIFF
--- a/quantified_flu/templates/base.html
+++ b/quantified_flu/templates/base.html
@@ -40,7 +40,7 @@
 
     <header>
       <!-- Fixed navbar -->
-      <nav class="navbar navbar-light navbar-expand-md fixed-top" style="background-image: linear-gradient(#FFFFFFFF, #ffffffdd, #ffffffbb, #ffffff00)">
+      <nav class="navbar navbar-light navbar-expand-md fixed-top" style="background-image: linear-gradient(#FFFFFFFF, #fffffffd, #ffffffed, #ffffffed)">
         <div class="container d-flex">
           <a class="navbar-brand" href="/">
             <img class="navbar-img" src="{% static 'img/icon-192x192.png' %}" style="max-height:2rem;">
@@ -51,6 +51,11 @@
           </button>
           <div class="collapse navbar-collapse text-right" id="navbarCollapse">
             <ul class="navbar-nav ml-auto">
+              {% if request.user.is_authenticated %}
+              <li class="nav-item mt-2 mt-md-0 mr-md-2">
+              <a class='nav-link' href="{% url 'manage-account' %}">Manage Account</a>
+            </li>
+              {% endif %}
               <li class="nav-item mt-2 mt-md-0 mr-md-2">
                 <a class="nav-link" href="{% url 'public-data' %}">Public data</a>
               </li>
@@ -64,7 +69,6 @@
                 </a>
               </li>
               {% else %}
-                <a class='nav-link' href="{% url 'manage-account' %}">Manage Account</a>
               <form class="mt-md-1 mt-0" action="{% url 'logout' %}" method="post">
                 {% csrf_token %}
                 <button class="btn btn-info btn-sm float-right" type="submit">Log out</button>

--- a/quantified_flu/templates/quantified_flu/about.html
+++ b/quantified_flu/templates/quantified_flu/about.html
@@ -75,6 +75,7 @@
           <ul>
             <li>All wearables by <i>Fitbit</i></li>
             <li>The <i>Oura</i> Ring</li>
+            <li>All wearables that can export to <i>Google Fit</i>, e.g. Android Smart Watches.</li>
           </ul>
           There are many popular wearables, so if your wearable of choice is missing: Let us know <a href="mailto:support@openhumans.org">via email</a> or by <a href='https://slackin.openhumans.org'>joining our Slack</a>.
           If you're a programmer and would like to add support for your own wearable: Amazing!
@@ -179,7 +180,7 @@
             and associated with connected accounts.
           </p>
           <p>
-            When you connect an Oura and/or Fitbit account, this site will access the
+            When you connect an Oura, Google Fit and/or Fitbit account, this site will access the
             following data and store it as an archive in your Open Humans
             account.
           </p>
@@ -207,8 +208,8 @@
           <p>
             You can always delete your account and all associated data from
             the <a href="#"><i>Dashboard</i></a>.
-            This includes the Open Humans and Oura/Fitbit authentication credentials,
-            i.e. we won't be able to access your Open Humans &amp; Oura/Fitbit
+            This includes the Open Humans and Oura/Fitbit/Google Fit authentication credentials,
+            i.e. we won't be able to access your Open Humans &amp; Oura/Fitbit/Google Fit
             accounts any longer.
           </p>
           <p>

--- a/quantified_flu/templates/quantified_flu/home.html
+++ b/quantified_flu/templates/quantified_flu/home.html
@@ -12,7 +12,7 @@
 <p>We have two ways you can contribute…</p>
 <h3>Report past illness</h3>
 <p>
-  Report when you got sick and share your wearable device data. <b>We'll plot your data for you!</b> Currently we support <em>Fitbit</em> & <em>Oura Ring</em> wearables.
+  Report when you got sick and share your wearable device data. <b>We'll plot your data for you!</b> Currently we support <em>Fitbit</em> & <em>Oura Ring</em> and <em>Google Fit</em>.
   <a href='https://docs.google.com/forms/d/e/1FAIpQLSdDjzLyL_HJ79ij4GbepqeNYAyYf4LWapXFyIDFwMRdXOBBXg/viewform'>Ask us to add support for your wearable</a>, if yours is missing so far!
 </p>
 <h3>Track symptoms going forward</h3>


### PR DESCRIPTION
I added the presence of *Google Fit* to the frontend in the frontpage and the `/about`. 

While I was at it I also re-ordered the menu items in the navbar (now Public Data & About don't jump around depending on whether a user is logged in or not) and fixed the transparency which looked strange on mobile devices (see screenshots for before/after). 

![Screenshot 2020-05-12 at 12 18 10](https://user-images.githubusercontent.com/674899/81672727-d88f9280-944a-11ea-95ba-814ba0b8dd3a.png)

![Screenshot 2020-05-12 at 12 17 58](https://user-images.githubusercontent.com/674899/81672772-eb09cc00-944a-11ea-90c8-0b533fe36b46.png)
