### PR TITLE
invert apple health to be consistent

### DIFF
--- a/import_data/activity_parsers.py
+++ b/import_data/activity_parsers.py
@@ -107,7 +107,7 @@ def apple_health_parser(apple_health_info, event_start, event_end=None):
                     {"timestamp": entry[1], "data": {"heart_rate": entry[0]},}
                 )
 
-    return returned_apple_data
+    return returned_apple_data[::-1]  # invert list as CSV is newest to oldest
 
 
 def googlefit_to_qf(json_data, min_date, max_date):
@@ -192,8 +192,6 @@ def garmin_parser(garmin_file_info, event_start, event_end=None):
     return data_in_qf_format
 
 
-
-
 def garmin_to_qf(json_data, min_date, max_date):
     res = []
     data = json_data
@@ -205,7 +203,7 @@ def garmin_to_qf(json_data, min_date, max_date):
             continue
         rec = {"timestamp": dt.isoformat(), "data": {"heart_rate": int(value)}}
         res.append(rec)
-        #print(rec)
+        # print(rec)
     return res
 
 

--- a/import_data/activity_parsers.py
+++ b/import_data/activity_parsers.py
@@ -104,10 +104,10 @@ def apple_health_parser(apple_health_info, event_start, event_end=None):
             sdate = arrow.get(entry[1])
             if sdate >= period_start and sdate <= period_end:
                 returned_apple_data.append(
-                    {"timestamp": entry[1], "data": {"heart_rate": entry[0]},}
+                    {"timestamp": entry[1], "data": {"heart_rate": entry[0]}}
                 )
-
-    return returned_apple_data[::-1]  # invert list as CSV is newest to oldest
+    returned_apple_data.reverse()  # invert list as CSV is newest to oldest
+    return returned_apple_data
 
 
 def googlefit_to_qf(json_data, min_date, max_date):


### PR DESCRIPTION
Turns out the Apple Health data is the 'wrong way around' as it's the only one using a CSV as input that is descending order, unlike the json files for all other integrations that consist of ascending lists. 

Closes #66 