### PR TITLE
[MRG] add oura nightly respiratory rate

### DIFF
--- a/import_data/activity_parsers.py
+++ b/import_data/activity_parsers.py
@@ -26,7 +26,7 @@ def oura_parser(oura_object, event_start, event_end=False):
 
     returned_hr_data = []
     returned_temp_data = []
-
+    returned_respiratory_rate_data = []
     # p is start_date!
 
     if "sleep" in oura.keys():
@@ -37,10 +37,14 @@ def oura_parser(oura_object, event_start, event_end=False):
             if sdate >= period_start and sdate <= period_end:
                 record_time = arrow.get(entry["bedtime_start"])
                 temperature_delta = entry.get("temperature_delta", 0)
+                respiratory_rate = entry.get("breath_average", 0)
                 returned_temp_data.append(
                     {
                         "timestamp": sdate.format("YYYY-MM-DD"),
-                        "data": {"temperature_delta": temperature_delta},
+                        "data": {
+                            "temperature_delta": temperature_delta,
+                            "respiratory_rate": respiratory_rate,
+                        },
                     }
                 )
                 for hr in entry["hr_5min"]:

--- a/retrospective/templates/retrospective/event.html
+++ b/retrospective/templates/retrospective/event.html
@@ -135,6 +135,10 @@
 
 <div class="retrospective_graph_{{ analysis.id }}"></div>
 
+{%if analysis.graph_type == 'oura_sleep_summary' %}
+<h3>Oura Respiratory Rate</h3>
+<div class="retrospective_graph_{{ analysis.id }}_rr"></div>
+{%endif%}
 {% endfor %}
 
 <script>
@@ -169,6 +173,25 @@
       y_label : 'body temperature',
       markers: markers,
       });
+      MG.data_graphic({
+        title: "Respiratory Rate",
+        description: "The nightly average respiratory rate as measured by Oura",
+        data: data,
+        chart_type: 'point',
+        width: 600,
+        height: 450,
+        top: 50,
+        left: 50,
+        right: 60,
+        full_width: true,
+        target: ".retrospective_graph_{{ analysis.id }}_rr",
+        x_accessor: "timestamp",
+        y_accessor: "respiratory_rate",
+        aggregate_rollover: true,
+        x_label : 'date',
+        y_label : 'respiratory_rate',
+        markers: markers,
+        });
     {% else %}
     MG.data_graphic({
       title: "Heart rate evolution",


### PR DESCRIPTION
Following our discussions at yesterday's community call and this morning on Slack I've taken a quick stab at adding the nightly respiratory rate from the Oura ring to fold it into the JSON endpoints and also the visualization we have for retrospective events (see screenshot below). 

As the data structure hasn't changed and this PR just adds another key to the existing  `data` entry for the `oura_sleep_summary` this shouldn't cause any compatibility issues downstream. 


![Screenshot 2020-06-24 at 16 16 18](https://user-images.githubusercontent.com/674899/85574137-cbafb280-b636-11ea-9abe-9df5ef5d30cf.png)

![Screenshot 2020-06-24 at 16 16 04](https://user-images.githubusercontent.com/674899/85574171-d36f5700-b636-11ea-9bd3-a3fc5d08ff17.png)
